### PR TITLE
fix: columns are very long when unbalanced

### DIFF
--- a/front/src/Components/DrawingList/index.tsx
+++ b/front/src/Components/DrawingList/index.tsx
@@ -1,4 +1,4 @@
-import { Card, Flex, Text } from '@mantine/core';
+import { Card, SimpleGrid, Text } from '@mantine/core';
 import { DrawingMetadata } from '../../types/Entity';
 
 export interface DrawingListProps {
@@ -13,13 +13,10 @@ const parseDate = (date: string) => (
 export const DrawingList = ({ files, onFileClick }: DrawingListProps) => {
 
   return (
-    <Flex p="md" gap="sm" wrap="wrap">
+    <SimpleGrid sx={{ padding: '1rem', gridTemplateColumns: 'repeat(auto-fit, minmax(15em, 1fr))' }} spacing="0.75rem">
       {files.map((file) => (
         <Card
           sx={{
-            flex: 1,
-            display: 'flex',
-            flexDirection: 'column',
             transition: 'transform 0.3s, box-shadow 0.3s',
             boxShadow: 'inset 0 0 0 0px rgb(193 194 197 / 0%)',
             ':hover' : {
@@ -28,13 +25,12 @@ export const DrawingList = ({ files, onFileClick }: DrawingListProps) => {
               transform: 'scale(1.03)'
             }
           }}
-          miw="min(15em, 100%)"
           key={file.id} 
           onClick={() => onFileClick(file.id)}>
           <Text weight='bold'>{file.name}</Text>
           <Text size="sm">{parseDate(file.created_at)}</Text>
         </Card>
       ))}
-    </Flex>
+    </SimpleGrid>
   );
 };


### PR DESCRIPTION
Currently the list of files is a flex, which means that the last row will expand to fit the entire screen. If the last row has less elements than other rows, they will look wider.

![image](https://github.com/Niv3K-El-Pato/ElPatoDraw/assets/1568690/c86555ef-bc8e-4c6a-8440-ace6497cc085)

The proposal is to replace Flex with SimpleGrid, so that the number of columns can be finite and thus they always left-align.

The old Flex used 15rem for each box, and the new system respects that, so it looks the same when the width of the browser is the same, only left-padded for the last row.

![image](https://github.com/Niv3K-El-Pato/ElPatoDraw/assets/1568690/b7aa60d4-544d-4e93-ac07-70e920bb8ecf)
