### PR TITLE
Add document search box

### DIFF
--- a/front/src/Components/DrawingList/index.tsx
+++ b/front/src/Components/DrawingList/index.tsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   Card,
   CloseButton,
   Group,

--- a/front/src/Components/DrawingList/index.tsx
+++ b/front/src/Components/DrawingList/index.tsx
@@ -1,5 +1,14 @@
-import { Card, SimpleGrid, Text } from '@mantine/core';
+import {
+  Button,
+  Card,
+  CloseButton,
+  Group,
+  SimpleGrid,
+  Text,
+  TextInput,
+} from '@mantine/core';
 import { DrawingMetadata } from '../../types/Entity';
+import { useEffect, useState } from 'react';
 
 export interface DrawingListProps {
   files: Array<DrawingMetadata>,
@@ -16,33 +25,73 @@ const parseDate = (date: string) => (
 );
 
 export const DrawingList = ({ files, onFileClick }: DrawingListProps) => {
+  const [searchQuery, setSearchQuery] = useState('');
 
-  const sortedFiles = [...files];
-  sortedFiles.sort((a, b) => {
-    const tsA = dateAsTimestamp(a.created_at);
-    const tsB = dateAsTimestamp(b.created_at);
-    return tsB - tsA;
+  const [sortedFiles, setSortedFiles] = useState<DrawingMetadata[]>([]);
+
+  useEffect(() => {
+    let realFiles;
+    if (!searchQuery) {
+      realFiles = [...files];
+    } else {
+      const lowerSearchQuery = searchQuery.toLocaleLowerCase();
+      realFiles = files.filter(
+        (f) => f.name.toLocaleLowerCase().indexOf(lowerSearchQuery) >= 0,
+      );
+    }
+    realFiles.sort((a, b) => {
+      const tsA = dateAsTimestamp(a.created_at);
+      const tsB = dateAsTimestamp(b.created_at);
+      return tsB - tsA;
+    });
+    setSortedFiles(realFiles);
   });
 
+  const Cancel = (
+    <CloseButton
+      variant="transparent"
+      onClick={() => setSearchQuery('')}
+      disabled={searchQuery.length === 0}
+      sx={{ ':disabled': { color: 'transparent' } }}
+    />
+  );
+
   return (
-    <SimpleGrid sx={{ padding: '1rem', gridTemplateColumns: 'repeat(auto-fit, minmax(15em, 1fr))' }} spacing="0.75rem">
-      {sortedFiles.map((file) => (
-        <Card
-          sx={{
-            transition: 'transform 0.3s, box-shadow 0.3s',
-            boxShadow: 'inset 0 0 0 0px rgb(193 194 197 / 0%)',
-            ':hover' : {
-              cursor: 'pointer',
-              boxShadow: 'inset 0 0 0 3px rgb(193 194 197 / 100%)',
-              transform: 'scale(1.03)'
-            }
-          }}
-          key={file.id} 
-          onClick={() => onFileClick(file.id)}>
-          <Text weight='bold'>{file.name}</Text>
-          <Text size="sm">{parseDate(file.created_at)}</Text>
-        </Card>
-      ))}
-    </SimpleGrid>
+    <>
+      <Group style={{ justifyContent: 'center' }}>
+        <TextInput
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.currentTarget.value)}
+          placeholder="Search..."
+          rightSection={Cancel}
+        />
+      </Group>
+      <SimpleGrid
+        sx={{
+          padding: '1rem',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(15em, 1fr))',
+        }}
+        spacing="0.75rem"
+      >
+        {sortedFiles.map((file) => (
+          <Card
+            sx={{
+              transition: 'transform 0.3s, box-shadow 0.3s',
+              boxShadow: 'inset 0 0 0 0px rgb(193 194 197 / 0%)',
+              ':hover': {
+                cursor: 'pointer',
+                boxShadow: 'inset 0 0 0 3px rgb(193 194 197 / 100%)',
+                transform: 'scale(1.03)',
+              },
+            }}
+            key={file.id}
+            onClick={() => onFileClick(file.id)}
+          >
+            <Text weight="bold">{file.name}</Text>
+            <Text size="sm">{parseDate(file.created_at)}</Text>
+          </Card>
+        ))}
+      </SimpleGrid>
+    </>
   );
 };

--- a/front/src/Components/DrawingList/index.tsx
+++ b/front/src/Components/DrawingList/index.tsx
@@ -29,7 +29,7 @@ export const DrawingList = ({ files, onFileClick }: DrawingListProps) => {
   const [sortedFiles, setSortedFiles] = useState<DrawingMetadata[]>([]);
 
   useEffect(() => {
-    let realFiles;
+    let realFiles: DrawingMetadata[];
     if (!searchQuery) {
       realFiles = [...files];
     } else {


### PR DESCRIPTION
Adds a search box that can filter documents by name.

https://github.com/user-attachments/assets/36af502e-1fae-425c-9f9d-4395d9c05ac7

Some things:

* Now I notice that if there are too few cards, then suddenly start to grow. This is noticeable if the user has just one, two or three cards, or if the document list is filtered. Or maybe if you have a very big screen.

* I feel like the DrawingList component has become suddenly too big with two useStates and one useEffect. I don't know if it's worth to split the component.