### PR TITLE
(Critical) Declare useEffect() dependencies to fix low app performance

### DIFF
--- a/front/src/Components/DrawingList/index.tsx
+++ b/front/src/Components/DrawingList/index.tsx
@@ -100,7 +100,7 @@ export const DrawingList = ({ files, onFileClick }: DrawingListProps) => {
       return tsB - tsA;
     });
     setSortedFiles(realFiles);
-  });
+  }, [searchQuery, files]);
 
   return (
     <>


### PR DESCRIPTION
Today I opened El Pato Draw to made some screen recordings and I noticed that the application was very laggy.

I initially suspected that this was because of using Firefox on GNU/Linux instead of Zen Browser on macOS like usual, and maybe not using properly graphical acceleration, but after testing [other](https://excalidraw.com/) [web](https://draw.moyu.io/) [apps](https://rbk.github.io/draw/) based on the same concept, I noticed that only El Pato Draw was laggy on this computer.

So I clone the repo on this machine, run `npm run dev`, open the browser and the developer tools, and I find a lot of red warnings about an `useEffect()` without dependencies.

And it turns out that the patch I prepared for #4 where I added the search field, does not actually declare the dependencies. I don't know how React works because I am a backend, but it may be that the callback is firing whenever it wants, and it has the side effect of delaying the performance of anything that uses reactivity, like maybe the `<Excalidraw/>` component.

After declaring the proper dependencies for the `useEffect()`, `localhost:5173` is not laggy anymore on Firefox for GNU/Linux so I think that this fixes the bug.