### PR TITLE
add file list footer with item count

### DIFF
--- a/Front UI/src/Components/DrawingList/index.tsx
+++ b/Front UI/src/Components/DrawingList/index.tsx
@@ -6,6 +6,7 @@ import { useTheme } from 'styled-components';
 import { SelectionBox } from '../SelectionBox';
 import { useEffect, useMemo, useRef } from 'react';
 import { Icon } from '@iconify/react';
+import { FileListFooter } from '../FileListFooter';
 
 export const DrawingList = () => {
   const filteredValue = useFileStorageStore(state => state.filteredValue);
@@ -70,6 +71,7 @@ export const DrawingList = () => {
           />
         ))}
       </S.FileGrid>
+      <FileListFooter />
     </S.Container>
   );
 };

--- a/Front UI/src/Components/FileListFooter/index.tsx
+++ b/Front UI/src/Components/FileListFooter/index.tsx
@@ -1,0 +1,31 @@
+import { useMemo } from 'react';
+import { useFileStorageStore } from '../../Store/FileStorageStore';
+import * as S from './styles';
+import { Icon } from '@iconify/react';
+
+
+export const FileListFooter = () => {
+  const currentFolder = useFileStorageStore(store => store.currentFolder);
+  const itemCount = useMemo(() => (
+    (currentFolder?.files.length ?? 0) + (currentFolder?.folders.length ?? 0)
+  ), [currentFolder]);
+
+  const selectedItemCount = useFileStorageStore(store => store.selectedItemIds.length);
+
+  return (
+    <S.Container>
+      <span>
+        {itemCount} items
+      </span>
+
+      {selectedItemCount > 0 && (
+        <>
+          <Icon aria-hidden icon='pepicons-pop:line-y' />
+          <span>
+            {selectedItemCount} item{selectedItemCount === 1 ? '' : 's'} selected
+          </span>
+        </>
+      )}
+    </S.Container>
+  );
+};

--- a/Front UI/src/Components/FileListFooter/styles.ts
+++ b/Front UI/src/Components/FileListFooter/styles.ts
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  padding: 0.5em 1em;
+  font-size: 0.9rem;
+  opacity: 0.8;
+
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+
+  border-top: solid 1px #ffffff24;
+`;


### PR DESCRIPTION
Added footer to file list that displays the item count and selection count

<img width="512" alt="image" src="https://github.com/user-attachments/assets/4cfbcb4d-1627-4c60-94ab-d5d49cee8244" />
<img width="509" alt="image" src="https://github.com/user-attachments/assets/c3adefe6-cbad-4c2b-a742-e4acc063e432" />

<img width="515" alt="image" src="https://github.com/user-attachments/assets/01b6f903-7bd7-4a2c-a3bc-6594960c1021" />

